### PR TITLE
ditch-callable

### DIFF
--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -6,11 +6,6 @@ from blinkstick.colors import hex_to_rgb, name_to_rgb, remap_color, remap_rgb_va
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.exceptions import BlinkStickException
 
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable
-
 if sys.platform == "win32":
     from blinkstick.backends.win32 import Win32Backend as USBBackend
     import pywinusb.hid as hid
@@ -243,7 +238,7 @@ class BlinkStick:
         r, g, b = self._get_color_rgb(index)
         return '#%02x%02x%02x' % (r, g, b)
 
-    def get_color(self, index=0, color_format='rgb'):
+    def get_color(self, index: int=0, color_format: str='rgb'):
         """
         Get the current backend color in the defined format.
 
@@ -270,10 +265,10 @@ class BlinkStick:
 
         # Attempt to find a function to return the appropriate format
         get_color_func = getattr(self, "_get_color_%s" % color_format, self._get_color_rgb)
-        if isinstance(get_color_func, Callable):
+        if callable(get_color_func):
             return get_color_func(index)
         else:
-            # Should never get here, as we should always default to self._get_color_rgb
+            # If the function is not callable, raise an exception
             raise BlinkStickException("Could not return current color in format %s" % color_format)
 
     def _determine_report_id(self, led_count):

--- a/tests/clients/blinkstick.py
+++ b/tests/clients/blinkstick.py
@@ -1,0 +1,32 @@
+import pytest
+from pytest_mock import MockFixture
+
+from blinkstick.blinkstick import BlinkStick, BlinkStickException
+
+def test_get_color_rgb(mocker: MockFixture):
+    """Test get_color with color_format='rgb'. We expect it to return the color in RGB format."""
+    mock_get_color_rgb = mocker.patch.object(BlinkStick, '_get_color_rgb', return_value=(255, 0, 0))
+    blinkstick = BlinkStick()
+    assert blinkstick.get_color() == (255, 0, 0)
+    assert mock_get_color_rgb.call_count == 1
+
+def test_get_color_hex(mocker):
+    """Test get_color with color_format='hex'. We expect it to return the color in hex format."""
+    mock_get_color_hex = mocker.patch.object(BlinkStick, '_get_color_hex', return_value='#ff0000')
+    blinkstick = BlinkStick()
+    assert blinkstick.get_color(color_format='hex') == '#ff0000'
+    assert mock_get_color_hex.call_count == 1
+
+def test_get_color_invalid_format(mocker):
+    """Test get_color with invalid color_format. We expect it not to raise an exception, but to default to RGB."""
+    mock_get_color_rgb = mocker.patch.object(BlinkStick, '_get_color_rgb', return_value=(255, 0, 0))
+    blinkstick = BlinkStick()
+    blinkstick.get_color(color_format='invalid_format')
+    assert mock_get_color_rgb.call_count == 1
+
+def test_non_callable_get_color(mocker):
+    """Test get_color with a non-callable get_color_func. We expect it to raise an exception."""
+    blinkstick = BlinkStick()
+    blinkstick._get_color_rgb = 'not_a_callable'
+    with pytest.raises(BlinkStickException):
+        blinkstick.get_color()


### PR DESCRIPTION
there's no need to import `callable` from collections and use isinstance etc., as the builtin callable is functionally equivalent. Also add tests for `get_color`