### PR TITLE
Refactor get_color

### DIFF
--- a/src/blinkstick/colors.py
+++ b/src/blinkstick/colors.py
@@ -1,6 +1,5 @@
 import re
-from enum import Enum
-
+from enum import Enum, auto
 
 HEX_COLOR_RE = re.compile(r'^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$')
 
@@ -179,6 +178,18 @@ def name_to_hex(name: str) -> str:
     '#daa520'
     """
     return Color.from_name(name).value
+
+
+class ColorFormat(Enum):
+    RGB = auto()
+    HEX = auto()
+
+    @classmethod
+    def from_name(cls, name):
+        try:
+            return cls[name.upper()]
+        except KeyError:
+            raise ValueError(f"'{name}' is not a supported color format.")
 
 
 def normalize_hex(hex_value: str) -> str:

--- a/tests/clients/test_blinkstick.py
+++ b/tests/clients/test_blinkstick.py
@@ -3,21 +3,21 @@ from pytest_mock import MockFixture
 
 from blinkstick.blinkstick import BlinkStick, BlinkStickException
 
-def test_get_color_rgb(mocker: MockFixture):
+def test_get_color_rgb_color_format(mocker: MockFixture):
     """Test get_color with color_format='rgb'. We expect it to return the color in RGB format."""
     mock_get_color_rgb = mocker.patch.object(BlinkStick, '_get_color_rgb', return_value=(255, 0, 0))
     blinkstick = BlinkStick()
     assert blinkstick.get_color() == (255, 0, 0)
     assert mock_get_color_rgb.call_count == 1
 
-def test_get_color_hex(mocker):
+def test_get_color_hex_color_format(mocker):
     """Test get_color with color_format='hex'. We expect it to return the color in hex format."""
     mock_get_color_hex = mocker.patch.object(BlinkStick, '_get_color_hex', return_value='#ff0000')
     blinkstick = BlinkStick()
     assert blinkstick.get_color(color_format='hex') == '#ff0000'
     assert mock_get_color_hex.call_count == 1
 
-def test_get_color_invalid_format(mocker):
+def test_get_color_invalid_color_format(mocker):
     """Test get_color with invalid color_format. We expect it not to raise an exception, but to default to RGB."""
     mock_get_color_rgb = mocker.patch.object(BlinkStick, '_get_color_rgb', return_value=(255, 0, 0))
     blinkstick = BlinkStick()

--- a/tests/clients/test_blinkstick.py
+++ b/tests/clients/test_blinkstick.py
@@ -24,9 +24,3 @@ def test_get_color_invalid_format(mocker):
     blinkstick.get_color(color_format='invalid_format')
     assert mock_get_color_rgb.call_count == 1
 
-def test_non_callable_get_color(mocker):
-    """Test get_color with a non-callable get_color_func. We expect it to raise an exception."""
-    blinkstick = BlinkStick()
-    blinkstick._get_color_rgb = 'not_a_callable'
-    with pytest.raises(BlinkStickException):
-        blinkstick.get_color()


### PR DESCRIPTION
Refactor the get_color method such that it makes use of an enum type to specify the color system which values should be returned in, and deprecates the `color_format` param in favour of a new `color_mode` param.