### PR TITLE
Use Enum to capture BlinkStick variant types

### DIFF
--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -3,7 +3,7 @@ import time
 from importlib.metadata import version
 
 from blinkstick.colors import hex_to_rgb, name_to_rgb, remap_color, remap_rgb_value, remap_rgb_value_reverse
-from blinkstick.constants import VENDOR_ID, PRODUCT_ID
+from blinkstick.constants import VENDOR_ID, PRODUCT_ID, BlinkStickVariant
 from blinkstick.exceptions import BlinkStickException
 
 if sys.platform == "win32":
@@ -31,16 +31,6 @@ class BlinkStick:
 
     U{https://github.com/arvydas/blinkstick-python/wiki}
     """
-
-
-
-    UNKNOWN = 0
-    BLINKSTICK = 1
-    BLINKSTICK_PRO = 2
-    BLINKSTICK_STRIP = 3
-    BLINKSTICK_SQUARE = 4
-    BLINKSTICK_NANO = 5
-    BLINKSTICK_FLEX = 6
 
     inverse = False
     error_reporting = True
@@ -86,61 +76,29 @@ class BlinkStick:
         """
         return self.backend.get_manufacturer()
 
-    def get_variant(self):
+    def get_variant(self) -> BlinkStickVariant:
         """
         Get the product variant of the backend.
 
         @rtype: int
-        @return: BlinkStick.UNKNOWN, BlinkStick.BLINKSTICK, BlinkStick.BLINKSTICK_PRO and etc
+        @return: BlinkStickVariant.UNKNOWN, BlinkStickVariant.BLINKSTICK, BlinkStickVariant.BLINKSTICK_PRO and etc
         """
 
         serial = self.get_serial()
         major = serial[-3]
-        minor = serial[-1]
 
         version_attribute = self.backend.get_version_attribute()
 
-        if major == "1":
-            return self.BLINKSTICK
-        elif major == "2":
-            return self.BLINKSTICK_PRO
-        elif major == "3":
-            if version_attribute == 0x200:
-                return self.BLINKSTICK_SQUARE
-            elif version_attribute == 0x201:
-                return self.BLINKSTICK_STRIP
-            elif version_attribute == 0x202:
-                return self.BLINKSTICK_NANO
-            elif version_attribute == 0x203:
-                return self.BLINKSTICK_FLEX
-            else:
-                return self.UNKNOWN
-        else:
-            return self.UNKNOWN
+        return BlinkStickVariant.identify(int(major), version_attribute)
 
-    def get_variant_string(self):
+    def get_variant_string(self) -> str:
         """
         Get the product variant of the backend as string.
 
         @rtype: string
         @return: "BlinkStick", "BlinkStick Pro", etc
         """
-        product = self.get_variant()
-
-        if product == self.BLINKSTICK:
-            return "BlinkStick"
-        elif product == self.BLINKSTICK_PRO:
-            return "BlinkStick Pro"
-        elif product == self.BLINKSTICK_SQUARE:
-            return "BlinkStick Square"
-        elif product == self.BLINKSTICK_STRIP:
-            return "BlinkStick Strip"
-        elif product == self.BLINKSTICK_NANO:
-            return "BlinkStick Nano"
-        elif product == self.BLINKSTICK_FLEX:
-            return "BlinkStick Flex"
-
-        return "Unknown"
+        return self.get_variant().description
 
     def get_description(self):
         """

--- a/src/blinkstick/constants.py
+++ b/src/blinkstick/constants.py
@@ -1,2 +1,40 @@
+from __future__ import annotations
+
+from enum import Enum
+
 VENDOR_ID = 0x20a0
 PRODUCT_ID = 0x41e5
+
+class BlinkStickVariant(Enum):
+    UNKNOWN = (0, "Unknown")
+    BLINKSTICK = (1, "BlinkStick")
+    BLINKSTICK_PRO = (2, "BlinkStick Pro")
+    BLINKSTICK_STRIP = (3, "BlinkStick Strip")
+    BLINKSTICK_SQUARE = (4, "BlinkStick Square")
+    BLINKSTICK_NANO = (5, "BlinkStick Nano")
+    BLINKSTICK_FLEX = (6, "BlinkStick Flex")
+
+    @property
+    def value(self):
+        return self._value_[0]
+
+    @property
+    def description(self):
+        return self._value_[1]
+
+    @staticmethod
+    def identify(major_version: int, version_attribute: int | None) -> "BlinkStickVariant":
+        if major_version == 1:
+            return BlinkStickVariant.BLINKSTICK
+        elif major_version == 2:
+            return BlinkStickVariant.BLINKSTICK_PRO
+        elif major_version == 3:
+            if version_attribute == 0x200:
+                return BlinkStickVariant.BLINKSTICK_SQUARE
+            elif version_attribute == 0x201:
+                return BlinkStickVariant.BLINKSTICK_STRIP
+            elif version_attribute == 0x202:
+                return BlinkStickVariant.BLINKSTICK_NANO
+            elif version_attribute == 0x203:
+                return BlinkStickVariant.BLINKSTICK_FLEX
+        return BlinkStickVariant.UNKNOWN

--- a/src/blinkstick/main.py
+++ b/src/blinkstick/main.py
@@ -2,6 +2,7 @@
 
 from optparse import OptionParser, IndentedHelpFormatter, OptionGroup
 from blinkstick import blinkstick
+from blinkstick.constants import BlinkStickVariant
 import textwrap
 import sys
 import logging
@@ -81,7 +82,7 @@ def print_info(stick):
     print("    Serial:        {0}".format(stick.get_serial()))
     print("    Current Color: {0}".format(stick.get_color(color_format="hex")))
     print("    Mode:          {0}".format(stick.get_mode()))
-    if stick.get_variant() == blinkstick.BlinkStick.BLINKSTICK_FLEX:
+    if stick.get_variant() == BlinkStickVariant.BLINKSTICK_FLEX:
         try:
             count = stick.get_led_count()
         except:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from blinkstick.blinkstick import BlinkStick
+
+
+@pytest.fixture
+def blinkstick():
+    bs = BlinkStick()
+    bs.backend = MagicMock()
+    return bs

--- a/tests/test_blinkstick.py
+++ b/tests/test_blinkstick.py
@@ -1,6 +1,61 @@
+from unittest.mock import MagicMock
+
+import pytest
+
 from blinkstick.blinkstick import BlinkStick
+from tests.conftest import blinkstick
 
 
 def test_instantiate():
     bs = BlinkStick()
     assert bs is not None
+
+@pytest.mark.parametrize("serial, version_attribute, expected_variant, expected_variant_value", [
+    ("BS12345-1.0", 0x0000, BlinkStick.BLINKSTICK, 1),
+    ("BS12345-2.0", 0x0000, BlinkStick.BLINKSTICK_PRO, 2),
+    ("BS12345-3.0", 0x200, BlinkStick.BLINKSTICK_SQUARE, 4), # major version 3, version attribute 0x200 is BlinkStickSquare
+    ("BS12345-3.0", 0x201, BlinkStick.BLINKSTICK_STRIP, 3), # major version 3 is BlinkStickStrip
+    ("BS12345-3.0", 0x202, BlinkStick.BLINKSTICK_NANO, 5),
+    ("BS12345-3.0", 0x203, BlinkStick.BLINKSTICK_FLEX, 6),
+    ("BS12345-4.0", 0x0000, BlinkStick.UNKNOWN, 0),
+    ("BS12345-3.0", 0x9999, BlinkStick.UNKNOWN, 0),
+    ("BS12345-0.0", 0x0000, BlinkStick.UNKNOWN, 0),
+], ids=[
+    "v1==BlinkStick",
+    "v2==BlinkStickPro",
+    "v3,0x200==BlinkStickSquare",
+    "v3,0x201==BlinkStickStrip",
+    "v3,0x202==BlinkStickNano",
+    "v3,0x203==BlinkStickFlex",
+    "v4==Unknown",
+    "v3,Unknown==Unknown",
+    "v0,0==Unknown"
+])
+def test_get_variant(blinkstick, serial, version_attribute, expected_variant, expected_variant_value):
+    blinkstick.get_serial = MagicMock(return_value=serial)
+    blinkstick.backend.get_version_attribute = MagicMock(return_value=version_attribute)
+    assert blinkstick.get_variant() == expected_variant
+    assert blinkstick.get_variant() == expected_variant_value
+
+
+@pytest.mark.parametrize("variant_value, expected_variant, expected_name", [
+    (1, BlinkStick.BLINKSTICK, "BlinkStick"),
+    (2, BlinkStick.BLINKSTICK_PRO, "BlinkStick Pro"),
+    (3, BlinkStick.BLINKSTICK_STRIP, "BlinkStick Strip"),
+    (4, BlinkStick.BLINKSTICK_SQUARE, "BlinkStick Square"),
+    (5, BlinkStick.BLINKSTICK_NANO, "BlinkStick Nano"),
+    (6, BlinkStick.BLINKSTICK_FLEX, "BlinkStick Flex"),
+    (0, BlinkStick.UNKNOWN, "Unknown"),
+], ids=[
+    "1==BlinkStick",
+    "2==BlinkStickPro",
+    "3==BlinkStickStrip",
+    "4==BlinkStickSquare",
+    "5==BlinkStickNano",
+    "6==BlinkStickFlex",
+    "0==Unknown"
+])
+def test_get_variant_string(blinkstick, variant_value, expected_variant, expected_name):
+    """Test get_variant method for version 0 returns BlinkStick.UNKNOWN (0)"""
+    blinkstick.get_variant = MagicMock(return_value=variant_value)
+    assert blinkstick.get_variant_string() == expected_name

--- a/tests/test_blinkstick.py
+++ b/tests/test_blinkstick.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from blinkstick.blinkstick import BlinkStick
+from blinkstick.constants import BlinkStickVariant
 from tests.conftest import blinkstick
 
 
@@ -11,15 +12,15 @@ def test_instantiate():
     assert bs is not None
 
 @pytest.mark.parametrize("serial, version_attribute, expected_variant, expected_variant_value", [
-    ("BS12345-1.0", 0x0000, BlinkStick.BLINKSTICK, 1),
-    ("BS12345-2.0", 0x0000, BlinkStick.BLINKSTICK_PRO, 2),
-    ("BS12345-3.0", 0x200, BlinkStick.BLINKSTICK_SQUARE, 4), # major version 3, version attribute 0x200 is BlinkStickSquare
-    ("BS12345-3.0", 0x201, BlinkStick.BLINKSTICK_STRIP, 3), # major version 3 is BlinkStickStrip
-    ("BS12345-3.0", 0x202, BlinkStick.BLINKSTICK_NANO, 5),
-    ("BS12345-3.0", 0x203, BlinkStick.BLINKSTICK_FLEX, 6),
-    ("BS12345-4.0", 0x0000, BlinkStick.UNKNOWN, 0),
-    ("BS12345-3.0", 0x9999, BlinkStick.UNKNOWN, 0),
-    ("BS12345-0.0", 0x0000, BlinkStick.UNKNOWN, 0),
+    ("BS12345-1.0", 0x0000, BlinkStickVariant.BLINKSTICK, 1),
+    ("BS12345-2.0", 0x0000, BlinkStickVariant.BLINKSTICK_PRO, 2),
+    ("BS12345-3.0", 0x200, BlinkStickVariant.BLINKSTICK_SQUARE, 4), # major version 3, version attribute 0x200 is BlinkStickSquare
+    ("BS12345-3.0", 0x201, BlinkStickVariant.BLINKSTICK_STRIP, 3), # major version 3 is BlinkStickStrip
+    ("BS12345-3.0", 0x202, BlinkStickVariant.BLINKSTICK_NANO, 5),
+    ("BS12345-3.0", 0x203, BlinkStickVariant.BLINKSTICK_FLEX, 6),
+    ("BS12345-4.0", 0x0000, BlinkStickVariant.UNKNOWN, 0),
+    ("BS12345-3.0", 0x9999, BlinkStickVariant.UNKNOWN, 0),
+    ("BS12345-0.0", 0x0000, BlinkStickVariant.UNKNOWN, 0),
 ], ids=[
     "v1==BlinkStick",
     "v2==BlinkStickPro",
@@ -35,17 +36,17 @@ def test_get_variant(blinkstick, serial, version_attribute, expected_variant, ex
     blinkstick.get_serial = MagicMock(return_value=serial)
     blinkstick.backend.get_version_attribute = MagicMock(return_value=version_attribute)
     assert blinkstick.get_variant() == expected_variant
-    assert blinkstick.get_variant() == expected_variant_value
+    assert blinkstick.get_variant().value == expected_variant_value
 
 
-@pytest.mark.parametrize("variant_value, expected_variant, expected_name", [
-    (1, BlinkStick.BLINKSTICK, "BlinkStick"),
-    (2, BlinkStick.BLINKSTICK_PRO, "BlinkStick Pro"),
-    (3, BlinkStick.BLINKSTICK_STRIP, "BlinkStick Strip"),
-    (4, BlinkStick.BLINKSTICK_SQUARE, "BlinkStick Square"),
-    (5, BlinkStick.BLINKSTICK_NANO, "BlinkStick Nano"),
-    (6, BlinkStick.BLINKSTICK_FLEX, "BlinkStick Flex"),
-    (0, BlinkStick.UNKNOWN, "Unknown"),
+@pytest.mark.parametrize("expected_variant, expected_name", [
+    (BlinkStickVariant.BLINKSTICK, "BlinkStick"),
+    (BlinkStickVariant.BLINKSTICK_PRO, "BlinkStick Pro"),
+    (BlinkStickVariant.BLINKSTICK_STRIP, "BlinkStick Strip"),
+    (BlinkStickVariant.BLINKSTICK_SQUARE, "BlinkStick Square"),
+    (BlinkStickVariant.BLINKSTICK_NANO, "BlinkStick Nano"),
+    (BlinkStickVariant.BLINKSTICK_FLEX, "BlinkStick Flex"),
+    (BlinkStickVariant.UNKNOWN, "Unknown"),
 ], ids=[
     "1==BlinkStick",
     "2==BlinkStickPro",
@@ -55,7 +56,7 @@ def test_get_variant(blinkstick, serial, version_attribute, expected_variant, ex
     "6==BlinkStickFlex",
     "0==Unknown"
 ])
-def test_get_variant_string(blinkstick, variant_value, expected_variant, expected_name):
+def test_get_variant_string(blinkstick, expected_variant, expected_name):
     """Test get_variant method for version 0 returns BlinkStick.UNKNOWN (0)"""
-    blinkstick.get_variant = MagicMock(return_value=variant_value)
+    blinkstick.get_variant = MagicMock(return_value=expected_variant)
     assert blinkstick.get_variant_string() == expected_name


### PR DESCRIPTION
This pull request refactors the BlinkStick variant identification logic by introducing an enumeration for BlinkStick variants. The changes improve code readability and maintainability by replacing hardcoded values with an `Enum` class and updating the related methods accordingly.

Key changes include:

### Refactoring BlinkStick Variant Identification:

* Introduced `BlinkStickVariant` enum in `src/blinkstick/constants.py` to represent different BlinkStick variants and their descriptions.
* Updated `get_variant` method in `src/blinkstick/blinkstick.py` to use `BlinkStickVariant.identify` for determining the variant based on the serial number and version attribute.
* Modified `get_variant_string` method in `src/blinkstick/blinkstick.py` to return the description from the `BlinkStickVariant` enum.

### Code Cleanup:

* Removed hardcoded variant constants from the `BlinkStick` class in `src/blinkstick/blinkstick.py`.

### Test Enhancements:

* Added unit tests in `tests/test_blinkstick.py` to verify the correct identification and string representation of BlinkStick variants using the new enum.
* Created a fixture in `tests/conftest.py` to mock BlinkStick instances for testing.